### PR TITLE
Add get permissions repo

### DIFF
--- a/json/16_g_get_permissions_on_repo.json
+++ b/json/16_g_get_permissions_on_repo.json
@@ -1,0 +1,1 @@
+{ "query": "{ repository(owner: \"__OWNER__\", name: \"__REPO__\") { collaborators(first: 50) { totalCount edges { permission permissionSources { permission roleName source { __typename ... on Organization { login } ... on Repository { name } ... on Team { slug } } } node { login name } } pageInfo { endCursor hasNextPage hasPreviousPage startCursor } } } }" }

--- a/run_interactive.sh
+++ b/run_interactive.sh
@@ -46,6 +46,7 @@ graphql_queries=(
   "List Repo Objects"
   "Query Pull Request Decisions"
   "Get File Object SHA"
+  "Get Permissions on Repo"
 )
 organization_queries=( 
   "List Organization Members"


### PR DESCRIPTION
GraphQL query addition:

* [`json/16_g_get_permissions_on_repo.json`](diffhunk://#diff-b8b4c60f95ac814a1bf7232a61a324db1d41c2e6d40da55a7a2465ce35446195R1): Added a new GraphQL query to fetch permissions for collaborators on a repository, including details about permission sources and collaborator information.

Script update:

* [`run_interactive.sh`](diffhunk://#diff-7b7119966c0793c9a0e1fba0ea53116afca57a20c646e92ba85812fe0235da83R49): Included the new "Get Permissions on Repo" query in the list of GraphQL queries available for interactive execution.